### PR TITLE
fix: ack poll write with dummy byte

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,9 @@ where
             .map_err(Error::I2cError)?;
 
         // ACK polling
+        const DUMMY: [u8; 1] = [0];
         for _ in 0..POLL_MAX_RETRIES {
-            if self.i2c.write(dev_addr, &[]).await.is_ok() {
+            if self.i2c.write(dev_addr, &DUMMY).await.is_ok() {
                 return Ok(());
             }
             self.delay.delay_us(POLL_DELAY_US).await;


### PR DESCRIPTION
Ack polling by writing an empty slice didn't work so we're just writing a dummy byte.